### PR TITLE
Streaming

### DIFF
--- a/vncrec/argsresources.c
+++ b/vncrec/argsresources.c
@@ -513,5 +513,6 @@ GetArgsAndResources(int argc, char **argv)
 	  exit (1);
 	}
       fwrite (magic, 1, strlen (magic), vncLog);
+      log_written += strlen(magic);
     }
 }

--- a/vncrec/argsresources.c
+++ b/vncrec/argsresources.c
@@ -434,6 +434,9 @@ GetArgsAndResources(int argc, char **argv)
 
     if (!isatty(0))
       appData.passwordDialog = True;
+
+    appData.passwordDialog = False;
+
     if (vncServerName[0] == '-')
       usage();
   }

--- a/vncrec/sockets.c
+++ b/vncrec/sockets.c
@@ -578,7 +578,7 @@ ReadFromRFBServer(char *out, unsigned int n)
         if (appData.record) {
 	  fwrite (out, 1, i, vncLog);
           log_written += i*1;
-          flush(vncLog);
+          fflush(vncLog);
         }
       }
       out += i;

--- a/vncrec/vncviewer.h
+++ b/vncrec/vncviewer.h
@@ -285,3 +285,4 @@ extern XtAppContext appContext;
 extern Display* dpy;
 extern Widget toplevel;
 extern FILE *vncLog;
+extern long log_written;


### PR DESCRIPTION
Hi Timo,

Basically scratching my own itch here... I made a modification which prevents vncrec from using `ftell()` and other modifications so as to be able to perform live streaming.
I don't think these patches (even the second) are conflicting with your aims, so, feel free to take a look and hopefully take it so I can destroy my fork.

Here's an usage example:
- First, create a FIFO and listen on it:

```
ssh ${GATEWAY_MACHINE_VERY_FAR} "rm -f vnc && mkfifo vnc && DISPLAY=:1 ~/.local/opt/bin/vncrec -movie vnc -writeYUV | ffmpeg -f yuv4mpegpipe -i - -f h264 -vcodec libx264 -bufsize 12k -minrate 10 -g 200 -crf 30 -x264opts intra-refresh -maxrate 800k -preset fast -tune zerolatency pipe:1" | ffplay -i -
```
- Then, write to the FIFO.

```
echo "${PASSWORD}" | ssh ${GATEWAY_MACHINE_VERY_FAR} "DISPLAY=:1 ~/.local/opt/bin/vncrec -record vnc -viewonly -encodings tight -compresslevel 9 -quality 0 ${VNC_SERVER}"
```

Thank you,
